### PR TITLE
Changes to setup-pointless-repo.sh

### DIFF
--- a/setup-pointless-repo.sh
+++ b/setup-pointless-repo.sh
@@ -1,8 +1,8 @@
 #!/data/data/com.termux/files/usr/bin/sh
 # Get some needed tools. coreutils for mkdir command, gnugp for the signing key, and apt-transport-https to actually connect to the repo
 apt-get update
-apt-get  --assume-yes upgrade 
-apt-get  --assume-yes install coreutils gnupg wget 
+apt-get --assume-yes upgrade
+apt-get --assume-yes install coreutils gnupg
 # Make the sources.list.d directory
 mkdir -p $PREFIX/etc/apt/sources.list.d
 # Write the needed source file
@@ -11,9 +11,11 @@ echo "deb https://its-pointless.github.io/files/24 termux extras" > $PREFIX/etc/
 else
 echo "deb https://its-pointless.github.io/files/ termux extras" > $PREFIX/etc/apt/sources.list.d/pointless.list
 fi
-# Download signing key from https://its-pointless.github.io/pointless.gpg 
-wget https://its-pointless.github.io/pointless.gpg
-apt-key add pointless.gpg
-rm pointless.gpg
+# Add signing key from https://its-pointless.github.io/pointless.gpg
+if [ -n $(command -v curl) ]; then
+curl -sL https://its-pointless.github.io/pointless.gpg | apt-key add -
+elif [ -n $(command -v wget) ]; then
+wget -qO - https://its-pointless.github.io/pointless.gpg | apt-key add -
+fi
 # Update apt
 apt update


### PR DESCRIPTION
Implement `if-else` to use either **cURL** or **Wget**.
Pipe to `apt-key add -` instead of downloading key file.