### PR TITLE
Update setup-pointless-repo.sh

### DIFF
--- a/setup-pointless-repo.sh
+++ b/setup-pointless-repo.sh
@@ -6,7 +6,7 @@ apt-get --assume-yes install coreutils gnupg
 # Make the sources.list.d directory
 mkdir -p $PREFIX/etc/apt/sources.list.d
 # Write the needed source file
-if apt-cache policy | grep -q "https://termux.org/packages" ; then
+if apt-cache policy | grep -q "termux.*24\|termux.org" ; then
 echo "deb https://its-pointless.github.io/files/24 termux extras" > $PREFIX/etc/apt/sources.list.d/pointless.list
 else
 echo "deb https://its-pointless.github.io/files/ termux extras" > $PREFIX/etc/apt/sources.list.d/pointless.list


### PR DESCRIPTION
Added new condition to the `grep` command Termux.
The website, `termux.org`, is down.
[Bintray package hosting](https://wiki.termux.com/wiki/Bintray_package_hosting)